### PR TITLE
Add box.json, support for generating PHAR file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,10 @@ composer.phar
 #editor related
 .idea
 
+# phar-generation specific
+box.json
+ahtletic.phar
+
 # OS generated files
 .DS_Store
 .DS_Store?

--- a/box.json.dist
+++ b/box.json.dist
@@ -1,0 +1,8 @@
+{
+  "main": "bootstrap.php",
+  "output": "athletic.phar",
+  "compactors": ["Herrera\\Box\\Compactor\\Composer"],
+  "chmod": "0755",
+  "directories": ["src/"],
+  "stub": true
+}


### PR DESCRIPTION
This PR adds a `box.json` file, that can be used with [kherge/Box](https://github.com/kherge/Box) to generate a `phar` file for Athletic. 

Instructions:
1. Install [kherge/Box](https://github.com/kherge/Box)
2. Assuming `box.phar` is somewhere in your `$PATH`, run:

``` shell
$ cd athletic/
$ box.phar build
```
1. `athletic.phar` will be generated and placed in the Athletic root dir. This file was also added to `.gitignore`

Cheers!
