### PR TITLE
Add error handling facilities

### DIFF
--- a/src/Athletic/Athletic.php
+++ b/src/Athletic/Athletic.php
@@ -32,6 +32,7 @@ class Athletic extends Pimple
 
     public function run()
     {
+        $this->setupErrorHandler();
         $classesToBenchmark = $this->getClassesToBenchmark();
         $this->benchmark($classesToBenchmark);
     }
@@ -59,6 +60,15 @@ class Athletic extends Pimple
         $suite->runSuite($classes);
         $suite->publishResults();
 
+    }
+
+    private function setupErrorHandler()
+    {
+        /** @var Athletic\Common\ErrorHandlerInterace $handler */
+        $handler = $this['errorHandler'];
+
+        set_exception_handler(array($handler, 'handleException'));
+        set_error_handler(array($handler, 'handleError'));
     }
 }
 

--- a/src/Athletic/Common/CmdLineErrorHandler.php
+++ b/src/Athletic/Common/CmdLineErrorHandler.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Athletic\Common;
+use Commando\Command;
+use ErrorException;
+
+/**
+* CmdLineErrorHandler
+* @package Athletic
+*/
+class CmdLineErrorHandler implements ErrorHandlerInterface
+{
+    /** @var Command $command */
+    private $command;
+
+    /**
+     * @param Command $command
+     */
+    public function __construct($command)
+    {
+        $this->command = $command;
+    }
+
+    /*
+     * {@inheritDoc}
+     */
+    public function handleException(\Exception $exception)
+    {
+        $this->command->error($exception);
+    }
+
+    /*
+     * {@inheritDoc}
+     */
+    public function handleError($errorLevel, $errorMessage, $errorFile, $errorLine, $errorContext = array())
+    {
+        // Translate the error to an ErrorException and delegate it to the
+        // exception handler:
+        $this->handleException(
+            new ErrorException($errorMessage, $errorLevel, null, $errorFile, $errorLine)
+        );
+    }
+}

--- a/src/Athletic/Common/DICBuilder.php
+++ b/src/Athletic/Common/DICBuilder.php
@@ -32,7 +32,6 @@ class DICBuilder
 
     public function buildDependencyGraph()
     {
-
         $this->setupDiscovery();
         $this->setupParser();
         $this->setupCmdLine();
@@ -43,7 +42,7 @@ class DICBuilder
         $this->setupClassRunner();
         $this->setupMethodResults();
         $this->setupClassResults();
-
+        $this->setupErrorHandler();
     }
 
 
@@ -72,8 +71,6 @@ class DICBuilder
             $path    = $cmdLine->getSuitePath();
             return new $dic['discoveryClass']($dic['parserFactory'], $path);
         };
-
-
     }
 
 
@@ -90,8 +87,6 @@ class DICBuilder
                 return new $dic['parserClass']($path);
             };
         };
-
-
     }
 
 
@@ -129,7 +124,6 @@ class DICBuilder
 
     private function setupCmdLine()
     {
-
         $this->athletic['cmdLine'] = function ($dic) {
             return new CmdLine($dic['command']);
         };
@@ -142,8 +136,6 @@ class DICBuilder
 
     private function setupFormatter()
     {
-
-
         $this->athletic['formatterClass'] = '\Athletic\Formatters\DefaultFormatter';
         $this->athletic['formatter']      = function ($dic) {
             return new $dic['formatterClass']();
@@ -162,11 +154,18 @@ class DICBuilder
 
     private function setupSuiteRunner()
     {
-
         $this->athletic['suiteRunnerClass'] = '\Athletic\Runners\SuiteRunner';
         $this->athletic['suiteRunner']      = function ($dic) {
             return new $dic['suiteRunnerClass']($dic['publisher'], $dic['classResultsFactory'], $dic['classRunnerFactory']);
         };
 
+    }
+
+    private function setupErrorHandler()
+    {
+        $this->athletic['errorHandlerClass'] = '\Athletic\Common\CmdLineErrorHandler';
+        $this->athletic['errorHandler'] = function($dic) {
+            return new $dic['errorHandlerClass']($dic['command']);
+        };
     }
 }

--- a/src/Athletic/Common/ErrorHandlerInterface.php
+++ b/src/Athletic/Common/ErrorHandlerInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Athletic\Common;
+
+/**
+* ErrorHandlerInterface
+* @package Athletic
+*/
+interface ErrorHandlerInterface
+{
+    /**
+     * @param int    $errorLevel
+     * @param string $errorMessage
+     * @param string $errorFile
+     * @param int    $errorLine
+     * @param array  $errorContext
+     */
+    public function handleError($errorLevel, $errorMessage, $errorFile, $errorLine, $errorContext = array());
+
+    /**
+     * @param \Exception $exception
+     */
+    public function handleException(\Exception $exception);   
+}


### PR DESCRIPTION
This PR introduces some base work for error handling facilities within Athletic, with basic support for pretty-printing errors using `Commando\Command::error` (default behavior). It's a bit of an opinionated PR, and may very well not fall within your plans for Athletic, so feel free to refuse or request changes at will, I will completely understand :smile:
