### PR TITLE
Removing registration of error handler - errors should not be catched

### DIFF
--- a/src/Athletic/Athletic.php
+++ b/src/Athletic/Athletic.php
@@ -70,7 +70,6 @@ class Athletic extends Pimple
         $handler = $this['errorHandler'];
 
         set_exception_handler(array($handler, 'handleException'));
-        set_error_handler(array($handler, 'handleError'));
     }
 }
 


### PR DESCRIPTION
Hotfix for #9

I honestly don't know how to test it since error handlers are not nested...
