### PR TITLE
Enabling PHP 5.3.3 builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ php:
   - "5.5"
   - "5.4"
   - "5.3"
+  - "5.3.3"
 
 before_script:
   - composer install --dev


### PR DESCRIPTION
This PR re-introduces builds for 5.3.3, which seems to be broken because of segfaults in https://travis-ci.org/Ocramius/LazyMap/jobs/13714803
