### PR TITLE
Accept Custom Formatter Classes

### DIFF
--- a/src/Athletic/Common/DICBuilder.php
+++ b/src/Athletic/Common/DICBuilder.php
@@ -213,11 +213,13 @@ class DICBuilder
     {
         $formatterInfo = new \ReflectionClass($formatterClass);
         if (!$formatterInfo->implementsInterface('Athletic\Formatters\FormatterInterface')) {
-            throw new \InvalidArgumentException();
+            $message = sprintf('%s does not implement the formatter interface.', $formatterClass);
+            throw new \InvalidArgumentException($message);
         }
         $constructor = $formatterInfo->getConstructor();
         if ($constructor !== null && $constructor->getNumberOfRequiredParameters() > 0) {
-            throw new \InvalidArgumentException();
+            $message = sprintf('Formatter %s must provide a constructor without required parameters.', $formatterClass);
+            throw new \InvalidArgumentException($message);
         }
     }
 }


### PR DESCRIPTION
This pull request allows one to specify the formatter class, which is used by Athletic, via command line.

If a class name is specified as `formatter` argument, then this class is used to format the benchmark results:

``` bash
$ php ./vendor/bin/athletic --formatter "My\Custom\FormatterClass" --path /home/ProjectDir/benchmarks/ --bootstrap /home/ProjectDir/vendor/autoload.php 
```

Classes that are used as formatter must implement `Athletic\Formatters\FormatterInterface` and provide a constructor without parameters.

The previous behavior of the `formatter` argument is preserved, which means that it is still possible to pass short names for built-in formatters.
