### PR TITLE
[POC} Added iterations and dataprovider

### DIFF
--- a/src/Athletic/Common/DICBuilder.php
+++ b/src/Athletic/Common/DICBuilder.php
@@ -115,8 +115,8 @@ class DICBuilder
 
         $this->athletic['methodResultsClass'] = '\Athletic\Results\MethodResults';
         $this->athletic['methodResults']      = function ($dic) {
-            return function ($name, $results, $iterations) use ($dic) {
-                return new $dic['methodResultsClass']($name, $results, $iterations);
+            return function ($name, $results, $iterations, $dataSet) use ($dic) {
+                return new $dic['methodResultsClass']($name, $results, $iterations, $dataSet);
             };
         };
     }

--- a/src/Athletic/Factories/MethodResultsFactory.php
+++ b/src/Athletic/Factories/MethodResultsFactory.php
@@ -24,8 +24,8 @@ class MethodResultsFactory extends AbstractFactory
      *
      * @return MethodResults
      */
-    public function create($name, $results, $iterations)
+    public function create($name, $results, $iterations, $dataSet)
     {
-        return $this->container['methodResults']($name, $results, $iterations);
+        return $this->container['methodResults']($name, $results, $iterations, $dataSet);
     }
 }

--- a/src/Athletic/Formatters/DefaultFormatter.php
+++ b/src/Athletic/Formatters/DefaultFormatter.php
@@ -31,22 +31,27 @@ class DefaultFormatter implements FormatterInterface
             $returnString .= $result->getClassName() . "\n";
 
             $longest = 0;
+            $longestDataSet = 0;
             /** @var MethodResults $methodResult */
             foreach ($result as $methodResult) {
-                if (strlen($methodResult->methodName) > $longest) {
-                    $longest = strlen($methodResult->methodName);
+                if (strlen($methodResult->getFullMethodName()) > $longest) {
+                    $longest = strlen($methodResult->getFullMethodName());
+                }
+                if (strlen($methodResult->getDataSetAsString()) > $longestDataSet) {
+                    $longestDataSet = strlen($methodResult->getDataSetAsString());
                 }
             }
             $returnString .= '    ' . str_pad(
                     'Method Name',
                     $longest
-                ) . "   Iterations    Average Time      Ops/second\n";
+                ) . "  Iterations   Average Time     Ops/second\n";
 
-            $returnString .= '    ' . str_repeat('-', $longest) . "  ------------  --------------    -------------\n";
+            $returnString .= '    ' . str_repeat('-', $longest) . "  ------------ ---------------- -------------\n";
 
             foreach ($result as $methodResult) {
 
-                $method     = str_pad($methodResult->methodName, $longest);
+                $method     = str_pad($methodResult->getFullMethodName(), $longest);
+                $iterations = str_pad(number_format($methodResult->iterations), 10);
                 $iterations = str_pad(number_format($methodResult->iterations), 10);
                 $avg        = str_pad(number_format($methodResult->avg, 13), 13);
                 $ops        = str_pad(number_format($methodResult->ops, 5), 7);

--- a/src/Athletic/Results/MethodResults.php
+++ b/src/Athletic/Results/MethodResults.php
@@ -23,9 +23,10 @@ class MethodResults
     public $ops;
     public $group;
     public $baseline = false;
+    public $dataSet;
 
 
-    public function __construct($name, $results, $iterations)
+    public function __construct($name, $results, $iterations, $dataSet)
     {
         $this->methodName = $name;
         $this->results    = $results;
@@ -36,8 +37,22 @@ class MethodResults
         $this->min        = min($results);
         $this->ops        = ($this->sum == 0.0) ? NAN : ($iterations / $this->sum);
         $this->baseline   = false;
+        $this->dataSet    = $dataSet;
     }
 
+    public function getDataSetAsString()
+    {
+        $res = array();
+        foreach ($this->dataSet as $name => $value) {
+            $res[] = $name . '=' . $value;
+        }
+        return implode(',', $res);
+    }
+
+    public function getFullMethodName()
+    {
+        return substr($this->methodName, 7) . '(' . $this->getDataSetAsString() .')';
+    }
 
     /**
      * @param string $group


### PR DESCRIPTION
This is a quick and dirty PR that:
- implements data providers 
- allows multiple iteration speciications 
- forces to prefix the method with `perform`.

If it is interesting I could break it up into separate PRs and write it properly...

For example:

``` php
    public function provideFullTreeTraversal()
    {
        return array(
            array(10, 100),
            array(20, 200),
        );
    }

    /**
     * @dataProvider provideFullTreeTraversal
     * @iterations 1
     * @iterations 10
     */
    public function performFullTreeTraversal($from, $to)
    {
        $rootNode = $this->getSession()->getRootNode();
        $this->iterateNode($rootNode);
    }
```

Produces:

```
PHPCR\Benchmark\Suites\Reading\TraversalEvent
    Method Name                        Iterations   Average Time     Ops/second
    ---------------------------------  ------------ ---------------- -------------
    FullTreeTraversal(from=10,to=100): [1         ] [0.0515341758728] [19.40460]
    FullTreeTraversal(from=10,to=100): [10        ] [0.0038705348969] [258.36222]
    FullTreeTraversal(from=20,to=200): [1         ] [0.0037219524384] [268.67619]
    FullTreeTraversal(from=20,to=200): [10        ] [0.0038553476334] [259.37998]
```
