### PR TITLE
Fix output formatting

### DIFF
--- a/src/Athletic/Formatters/DefaultFormatter.php
+++ b/src/Athletic/Formatters/DefaultFormatter.php
@@ -74,7 +74,7 @@ class DefaultFormatter implements FormatterInterface
                 $returnString .= sprintf(
                     "    %s: [%s] [%s] [%s]\n",
                     str_pad($row[0], $lengths[0]),
-                    str_pad($row[1], $lengths[1]),
+                    str_pad($row[1], $lengths[1], ' ', STR_PAD_LEFT),
                     str_pad($row[2], $lengths[2]),
                     str_pad($row[3], $lengths[3])
                 );

--- a/tests/Athletic/Formatters/DefaultFormatterTest.php
+++ b/tests/Athletic/Formatters/DefaultFormatterTest.php
@@ -55,7 +55,7 @@ class DefaultFormatterTest extends \PHPUnit_Framework_TestCase
 testClass
     Method Name   Iterations   Average Time      Ops/second
     ------------ ------------ ----------------- ------------
-    testName   : [5         ] [5.0000000000000] [5.00000   ]
+    testName   : [         5] [5.0000000000000] [5.00000   ]
 
 
 
@@ -99,9 +99,9 @@ EOF;
 testClass
     Method Name   Iterations   Average Time      Ops/second
     ------------ ------------ ----------------- ------------
-    testName   : [5         ] [5.0000000000000] [5.00000   ]
-    testName   : [5         ] [5.0000000000000] [5.00000   ]
-    testName   : [5         ] [5.0000000000000] [5.00000   ]
+    testName   : [         5] [5.0000000000000] [5.00000   ]
+    testName   : [         5] [5.0000000000000] [5.00000   ]
+    testName   : [         5] [5.0000000000000] [5.00000   ]
 
 
 
@@ -145,19 +145,19 @@ EOF;
 testClass
     Method Name   Iterations   Average Time      Ops/second
     ------------ ------------ ----------------- ------------
-    testName   : [5         ] [5.0000000000000] [5.00000   ]
+    testName   : [         5] [5.0000000000000] [5.00000   ]
 
 
 testClass
     Method Name   Iterations   Average Time      Ops/second
     ------------ ------------ ----------------- ------------
-    testName   : [5         ] [5.0000000000000] [5.00000   ]
+    testName   : [         5] [5.0000000000000] [5.00000   ]
 
 
 testClass
     Method Name   Iterations   Average Time      Ops/second
     ------------ ------------ ----------------- ------------
-    testName   : [5         ] [5.0000000000000] [5.00000   ]
+    testName   : [         5] [5.0000000000000] [5.00000   ]
 
 
 


### PR DESCRIPTION
The output of the default formatter is slightly off, as even the expected data in tests already show. I made sure that the columns are resized according to the largest value. I also changed the alignment of the number of iterations so that the tens are stacked in one row of the output.
