### PR TITLE
AthleticEvent::pause() and ::resume()

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -194,7 +194,7 @@ Athletic offers several methods to setup and tear down data/variables.
 | Method | Description |
 | ------ | ----------- |
 | classSetUp() | Invoked at the beginning of the Event before anything else has occurred |
-| setUp() | Invoked once before each iteration of the method being benchmark.|
+| setUp() | Invoked once before each iteration of the method being benchmarked.|
 | classTearDown() | Invoked at the end of the event after everything else has occurred.|
 | tearDown() | Invoked after each iteration of a benchmark has completed.|
 
@@ -207,3 +207,20 @@ If the goal, however, is to benchmark the entire process (initial calculation an
 ### Calibration
 
 Athletic uses Reflection and variable functions to invoke the methods in your Event.  Because there is some internal overhead to variable functions, Athletic performs a "calibration" step before each iteration.  This step calls an empty calibration method and times how long it takes.  This time is then subtracted from the iterations total time, providing a more accurate total time.
+
+### Pause Benchmarks
+
+Benchmarks can be paused within the benchmarking methods by calling `$this->pause()`. Execution time of code following a pause call will not affect the benchmark result. Calling `$this->resume()` will resume the benchmark.
+
+```php
+/**
+ * @iterations 1000
+ */
+public function fastIndexingAlgo()
+{
+    $this->pause();
+    $indexer = new Indexing\FastIndexer();
+    $this->resume();
+    $indexer->index($this->data);
+}
+```

--- a/src/Athletic/AthleticEvent.php
+++ b/src/Athletic/AthleticEvent.php
@@ -174,7 +174,6 @@ abstract class AthleticEvent
                 . "resume() call expected before next pause");
         }
         $this->pauseStart = microtime(true);
-        return $this;
     }
 
 
@@ -191,7 +190,6 @@ abstract class AthleticEvent
         $pauseStart = $this->pauseStart;
         $this->pauseStart = null;
         $this->pauseTimes[] = microtime(true) - $pauseStart;
-        return $this;
     }
 
 

--- a/src/Athletic/AthleticEvent.php
+++ b/src/Athletic/AthleticEvent.php
@@ -11,6 +11,7 @@ use Athletic\Factories\MethodResultsFactory;
 use Athletic\Results\MethodResults;
 use ReflectionClass;
 use zpt\anno\Annotations;
+use LogicException;
 
 /**
  * Class AthleticEvent
@@ -18,8 +19,17 @@ use zpt\anno\Annotations;
  */
 abstract class AthleticEvent
 {
-    /** @var  MethodResultsFactory */
+    /** @var MethodResultsFactory */
     private $methodResultsFactory;
+
+    /** @var string|null */
+    private $timeMethodCurrentMethod;
+
+    /** @var float|null */
+    private $pauseStart = null;
+
+    /** @var float[] */
+    private $pauseTimes;
 
 
     public function __construct()
@@ -128,15 +138,60 @@ abstract class AthleticEvent
 
 
     /**
+	 * @todo Move timer into separate class.
+	 *
      * @param string $method
      *
      * @return mixed
      */
     private function timeMethod($method)
     {
+        $this->pauseTimes = array();
+        $this->timeMethodCurrentMethod = $method;
+
         $start = microtime(true);
         $this->$method();
-        return microtime(true) - $start;
+        $endTime = microtime(true);
+
+        if( $this->pauseStart !== null ) {
+            throw new LogicException("[$method] resume() has not been called after pause()");
+        }
+
+        $this->timeMethodCurrentMethod = null;
+        return $endTime - $start - array_sum( $this->pauseTimes );
+    }
+
+
+    /**
+     * Allows to pause a benchmark. Time elapsed for code invoked between pause() and subsequent
+     * resume() call will not be part of the benchmark result.
+     *
+     * @return $this
+     */
+    public function pause() {
+        if( $this->pauseStart !== null ) {
+            throw new LogicException( "[{$this->timeMethodCurrentMethod}] pause() still active, "
+                . "resume() call expected before next pause");
+        }
+        $this->pauseStart = microtime(true);
+        return $this;
+    }
+
+
+    /**
+     * Resumes the benchmark after a pause() call.
+     *
+     * @return $this
+     */
+    public function resume() {
+        if( $this->pauseStart === null ) {
+            throw new LogicException("[{$this->timeMethodCurrentMethod}] can not resume() a "
+                . " benchmark before initiating pause()");
+        }
+        $pauseStart = $this->pauseStart;
+        $this->pauseStart = null;
+        $this->pauseTimes[] = microtime(true) - $pauseStart;
+        return $this;
     }
 
 

--- a/tests/Athletic/TestAsset/BenchmarkCallbackEvent.php
+++ b/tests/Athletic/TestAsset/BenchmarkCallbackEvent.php
@@ -23,7 +23,7 @@ class BenchmarkCallbackEvent extends AthleticEvent
     {
         // Have to put this in an array or AthleticEvent will recognize it as an actual benchmark.
         // That might be no problem but make sure and invoke callback in a more controlled fashion.
-        $this->benchmarkCode = [$benchmarkCode];
+        $this->benchmarkCode = array($benchmarkCode);
     }
 
     /**

--- a/tests/Athletic/TestAsset/BenchmarkCallbackEvent.php
+++ b/tests/Athletic/TestAsset/BenchmarkCallbackEvent.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Athletic\TestAsset;
+
+use Athletic\AthleticEvent;
+
+/**
+ * Test event which will execute a constructor given callback in its one benchmark function.
+ *
+ * @author Daniel A. R. Werner <daniel.a.r.werner@gmail.com>
+ *
+ * @package Athletic\TestAsset
+ */
+class BenchmarkCallbackEvent extends AthleticEvent
+{
+	/** @var array( callback ) */
+	protected $benchmarkCode;
+
+	/**
+	 * @param callable $benchmarkCode Callback executed in the "someBenchmark" benchmark member.
+	 *        The callback gets the BenchmarkCallbackEvent instance passed in as first argument.
+	 */
+    public function __construct( $benchmarkCode ) {
+		// Have to put this in an array or AthleticEvent will recognize it as an actual benchmark.
+		// That might be no problem but make sure and invoke callback in a more controlled fashion.
+		$this->benchmarkCode = [ $benchmarkCode ];
+	}
+
+    /**
+     * @iterations 3
+     */
+    public function someBenchmark()
+    {
+        return $this->benchmarkCode[ 0 ]( $this );
+    }
+}

--- a/tests/Athletic/TestAsset/BenchmarkCallbackEvent.php
+++ b/tests/Athletic/TestAsset/BenchmarkCallbackEvent.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Athletic\TestAsset;
 
 use Athletic\AthleticEvent;
@@ -13,24 +12,25 @@ use Athletic\AthleticEvent;
  */
 class BenchmarkCallbackEvent extends AthleticEvent
 {
-	/** @var array( callback ) */
-	protected $benchmarkCode;
+    /** @var array(callback) */
+    protected $benchmarkCode;
 
-	/**
-	 * @param callable $benchmarkCode Callback executed in the "someBenchmark" benchmark member.
-	 *        The callback gets the BenchmarkCallbackEvent instance passed in as first argument.
-	 */
-    public function __construct( $benchmarkCode ) {
-		// Have to put this in an array or AthleticEvent will recognize it as an actual benchmark.
-		// That might be no problem but make sure and invoke callback in a more controlled fashion.
-		$this->benchmarkCode = [ $benchmarkCode ];
-	}
+    /**
+     * @param callable $benchmarkCode Callback executed in the "someBenchmark" benchmark member.
+     *        The callback gets the BenchmarkCallbackEvent instance passed in as first argument.
+     */
+    public function __construct($benchmarkCode)
+    {
+        // Have to put this in an array or AthleticEvent will recognize it as an actual benchmark.
+        // That might be no problem but make sure and invoke callback in a more controlled fashion.
+        $this->benchmarkCode = [$benchmarkCode];
+    }
 
     /**
      * @iterations 3
      */
     public function someBenchmark()
     {
-        return $this->benchmarkCode[ 0 ]( $this );
+        return $this->benchmarkCode[0]($this);
     }
 }


### PR DESCRIPTION
Benchmarks can be paused within the benchmarking methods by calling `$this->pause()`. Execution time of code following a pause call will not affect the benchmark result. Calling `$this->resume()` will resume the benchmark.
